### PR TITLE
Override previous main with using internal position control for continuous positioning

### DIFF
--- a/include/feetech_cpp_lib/feetech_lib.hpp
+++ b/include/feetech_cpp_lib/feetech_lib.hpp
@@ -157,6 +157,12 @@ public:
     /// \param[in] positionOffset new position offset
     /// \return True if servo could successfully change position offset
     bool writePositionOffset(uint8_t const &servoId, int const &positionOffset);
+
+    /// \brief Read the position offset of a servo.
+    /// \param[in] servoId servo ID
+    /// \param[out] positionOffset position offset
+    /// \return Position offset, -1 on read failure, -2 on servo type failure.
+    bool readPositionOffset(uint8_t const &servoId, int16_t &positionOffset);
     
     /// @brief Set new driver settings.
     /// @param settings 
@@ -184,6 +190,12 @@ public:
     /// \param[in] servoId ID of the servo
     /// \return Position, in rad, -1 on read failure, -2 on servo type failure.
     double readCurrentPosition(uint8_t const &servoId);
+
+    /// \brief Get current servo position in ticks.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \return Position, in ticks, -1 on read failure, -2 on servo type failure.
+    int16_t readCurrentPositionTicks(uint8_t const &servoId);
 
     /// \brief Get current servo speed.
     /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
@@ -245,7 +257,7 @@ public:
     /// \param[in] servoId ID of the servo
     /// \param[in] maxAngle Maximum angle in radians
     /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-    bool writeMaxAngle(uint8_t const &servoId, double const &maxAngle);
+    bool writeMaxAngle(uint8_t const &servoId, int16_t const &maxAngle);
 
     /// \brief Trigger the action previously stored by an asynchronous write on all servos.
     /// \return True on success
@@ -353,11 +365,11 @@ public:
     /// @brief Set the current position as servo home position. Adjust current positions and reference positions 
     ///         to account for new home.
     /// @param[in] servoId ID of the servo
-    void setHomePosition(uint8_t const &servoId);
+    void resetHomePosition(uint8_t const &servoId);
 
     /// @brief Get the home positions for all servos.
     /// @return Vector of home positions in radians.
-    std::vector<double> getHomePositions();
+    std::vector<int16_t> getHomePositions();
 
     /// @brief Set the current positions for all servos as their home positions. Adjust current positions and reference positions
     ///         to account for new home.
@@ -502,7 +514,7 @@ private:
     std::vector<double> currentVelocities_;
     std::vector<double> currentTemperatures_;
     std::vector<double> currentCurrents_;
-    std::vector<double> homePositions_;
+    std::vector<int16_t> homePositions_; // In ticks at horn
 
     // Servo settings
     std::vector<DriverMode> operatingModes_;

--- a/include/feetech_cpp_lib/feetech_lib.hpp
+++ b/include/feetech_cpp_lib/feetech_lib.hpp
@@ -156,7 +156,7 @@ public:
     /// \param[in] servoId servo ID
     /// \param[in] positionOffset new position offset
     /// \return True if servo could successfully change position offset
-    bool setPositionOffset(uint8_t const &servoId, int const &positionOffset);
+    bool writePositionOffset(uint8_t const &servoId, int const &positionOffset);
     
     /// @brief Set new driver settings.
     /// @param settings 

--- a/include/feetech_cpp_lib/feetech_lib.hpp
+++ b/include/feetech_cpp_lib/feetech_lib.hpp
@@ -259,6 +259,12 @@ public:
     /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
     bool writeMaxAngle(uint8_t const &servoId, int16_t const &maxAngle);
 
+    /// @brief Set torque enable
+    /// @param servoId ID of the servo
+    /// @param enable True for enabling, false for disabling
+    /// @return True if success
+    bool writeTorqueEnable(uint8_t const &servoId, bool const enable);
+
     /// \brief Trigger the action previously stored by an asynchronous write on all servos.
     /// \return True on success
     bool trigerAction();

--- a/include/feetech_cpp_lib/feetech_lib.hpp
+++ b/include/feetech_cpp_lib/feetech_lib.hpp
@@ -235,6 +235,18 @@ public:
     /// \param[in] mode Desired mode
     bool writeMode(unsigned char const& servoId, STSMode const& mode);
 
+    /// \brief Set the minimum angle of a servo.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] minAngle Minimum angle in radians
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    bool writeMinAngle(uint8_t const &servoId, double const &minAngle);
+
+    /// \brief Set the maximum angle of a servo.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] maxAngle Maximum angle in radians
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    bool writeMaxAngle(uint8_t const &servoId, double const &maxAngle);
+
     /// \brief Trigger the action previously stored by an asynchronous write on all servos.
     /// \return True on success
     bool trigerAction();

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -842,7 +842,7 @@ int FeetechServo::receiveMessage(uint8_t const& servoId,
     boost::system::error_code read_ec, timer_ec;
     std::size_t bytes_read = 0;
 
-    int serial_timeout_ms = static_cast<int>(settings_.tx_time_per_byte * (readLength + 5) + 10);
+    int serial_timeout_ms = static_cast<int>(settings_.tx_time_per_byte * (readLength + 5) + 25);
 
     boost::asio::steady_timer timer(*io_context_);
     bool read_done = false, timer_expired = false;

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -79,7 +79,7 @@ FeetechServo::FeetechServo(std::string port, long const &baud, const double freq
     if (settings_.logging)
     {
         std::cerr << "\033[31m" << "Creating logging file" << "\033[0m" << std::endl;
-        new ServoSerialLogger("serial_log.txt"); // TODO: Where is this file created?
+        this-> logger_ = std::make_shared<ServoSerialLogger>("/ros2_ws/aerial_tactile_servoing/data/serial_log.txt"); // TODO: Where is this file created?
     }
     // Read all data once to populate data structs
     bool success=false;

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -103,6 +103,7 @@ FeetechServo::FeetechServo(std::string port, long const &baud, const double freq
     {
         writeMaxAngle(servoIds_[i], 0);
         resetHomePosition(servoIds_[i]);
+        writeTorqueEnable(servoIds_[i], true);
         writeTargetVelocity(servoIds_[i], 0, false);
         writeMode(servoIds_[i], STSMode::STS_POSITION);
     }
@@ -138,6 +139,13 @@ FeetechServo::~FeetechServo()
 {
     // Set velocity to zero
     stopAll();
+
+    // Set torque disable
+    for (size_t i = 0; i < servoIds_.size(); ++i)
+    {
+        writeTorqueEnable(servoIds_[i], false);
+    }
+    
     // Close serial port
     close();
     // Delete serial port and io_context
@@ -451,6 +459,11 @@ bool FeetechServo::writeMinAngle(uint8_t const &servoId, double const &minAngle)
 bool FeetechServo::writeMaxAngle(uint8_t const &servoId, int16_t const &maxAngle)
 {
     return writeTwouint8_tsRegister(servoId, STSRegisters::MAXIMUM_ANGLE, maxAngle);
+}
+
+bool FeetechServo::writeTorqueEnable(uint8_t const &servoId, bool const enable)
+{
+    return writeRegister(servoId, STSRegisters::TORQUE_SWITCH, static_cast<int8_t>(enable));
 }
 
 void FeetechServo::setReferencePosition(uint8_t const &servoId, double const &position)

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -310,9 +310,9 @@ double FeetechServo::readCurrentPosition(uint8_t const &servoId)
         std::cerr << "\033[31m" << "[ID "<< static_cast<int>(servoId)<< "] "<< "[ERROR] Failed to read current position (pos == -2)" << "\033[0m" << std::endl;
         return -2;
     }
-    double current_position_rads = (absolute_position_ticks * RADIANS_PER_TICK) / gearRatios_[idToIndex_[servoId]] - homePositions_[idToIndex_[servoId]];
-    // std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position ticks: " << absolute_position_ticks << " ticks "<< std::endl;
-    // std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position: " << current_position_rads << " rads "<< std::endl;
+    double current_position_rads = ((absolute_position_ticks - homePositions_[idToIndex_[servoId]]) * RADIANS_PER_TICK) / gearRatios_[idToIndex_[servoId]];
+    std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position ticks: " << absolute_position_ticks << " ticks "<< std::endl;
+    std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position: " << current_position_rads << " rads "<< std::endl;
 
     return currentPositions_[idToIndex_[servoId]] = current_position_rads;
 }

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -151,11 +151,11 @@ bool FeetechServo::execute()
         // Position mode
         if (operatingModes_[i] == DriverMode::CONTINUOUS_POSITION)
         {
-            std::cout<< "Reference position output in rad " << referencePositions_[i].load(std::memory_order_relaxed) << std::endl;
+            std::cout<< "[ID: " << servoIds_[i]<<"]"<< "Reference position output in rad " << referencePositions_[i].load(std::memory_order_relaxed) << std::endl;
             int position = static_cast<int>(referencePositions_[i].load(std::memory_order_relaxed)*gearRatios_[i]*TICKS_PER_RADIAN + 
                 homePositions_[i]);
             writeTargetPosition(servoIds_[i], position);
-            std::cout << "Wrote target position as ticks: " << position << std::endl;
+            std::cout << "[ID: " << servoIds_[i]<<"]"<< "Wrote target position as ticks: " << position << std::endl;
         }
         // Velocity mode
         else if (operatingModes_[i] == DriverMode::VELOCITY)
@@ -284,7 +284,7 @@ double FeetechServo::readCurrentPosition(uint8_t const &servoId)
     int16_t absolute_position_ticks = readTwouint8_tsRegister(servoId, STSRegisters::CURRENT_POSITION);
     double current_position_rads = (absolute_position_ticks * RADIANS_PER_TICK) / gearRatios_[idToIndex_[servoId]];
 
-    std::cout << "Current position: " << current_position_rads << " rads "<< std::endl;
+    std::cout << "[ID: " << servoId<<"]"<<"Current position: " << current_position_rads << " rads "<< std::endl;
 
     return currentPositions_[idToIndex_[servoId]] = current_position_rads;
 }
@@ -561,6 +561,9 @@ void FeetechServo::resetHomePosition(uint8_t const &servoId)
 {
     // Get current position
     int16_t current_position = readCurrentPositionTicks(servoId);
+
+    // Print setting home position
+    std::cout<< "[ID: " << servoId<<"]" << "Setting home position as: " << current_position << std::endl;
     // Assign current position as home
     homePositions_[idToIndex_[servoId]] = current_position;
 }

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -310,7 +310,7 @@ double FeetechServo::readCurrentPosition(uint8_t const &servoId)
         std::cerr << "\033[31m" << "[ID "<< static_cast<int>(servoId)<< "] "<< "[ERROR] Failed to read current position (pos == -2)" << "\033[0m" << std::endl;
         return -2;
     }
-    double current_position_rads = (absolute_position_ticks * RADIANS_PER_TICK) / gearRatios_[idToIndex_[servoId]];
+    double current_position_rads = (absolute_position_ticks * RADIANS_PER_TICK) / gearRatios_[idToIndex_[servoId]] - homePositions_[idToIndex_[servoId]];
     // std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position ticks: " << absolute_position_ticks << " ticks "<< std::endl;
     // std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position: " << current_position_rads << " rads "<< std::endl;
 

--- a/src/feetech_lib.cpp
+++ b/src/feetech_lib.cpp
@@ -156,11 +156,11 @@ bool FeetechServo::execute()
             // Position mode
             if (operatingModes_[i] == DriverMode::CONTINUOUS_POSITION)
             {
-                std::cout<< "[ID: " << static_cast<int>(servoIds_[i])<<"] "<< "Reference position output in rad " << referencePositions_[i].load(std::memory_order_relaxed) << std::endl;
+                // std::cout<< "[ID: " << static_cast<int>(servoIds_[i])<<"] "<< "Reference position output in rad " << referencePositions_[i].load(std::memory_order_relaxed) << std::endl;
                 int position = static_cast<int>(directions_[i]* referencePositions_[i].load(std::memory_order_relaxed)*gearRatios_[i]*TICKS_PER_RADIAN + 
                     homePositions_[i]);
                 writeTargetPosition(servoIds_[i], position, maxSpeeds_[i]*gearRatios_[i]*TICKS_PER_RADIAN);
-                std::cout << "[ID: " << static_cast<int>(servoIds_[i])<<"] "<< "Wrote target position as ticks: " << position << std::endl;
+                // std::cout << "[ID: " << static_cast<int>(servoIds_[i])<<"] "<< "Wrote target position as ticks: " << position << std::endl;
             }
             // Velocity mode
             else if (operatingModes_[i] == DriverMode::VELOCITY)
@@ -303,8 +303,8 @@ double FeetechServo::readCurrentPosition(uint8_t const &servoId)
         return -2;
     }
     double current_position_rads = (absolute_position_ticks * RADIANS_PER_TICK) / gearRatios_[idToIndex_[servoId]];
-    std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position ticks: " << absolute_position_ticks << " ticks "<< std::endl;
-    std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position: " << current_position_rads << " rads "<< std::endl;
+    // std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position ticks: " << absolute_position_ticks << " ticks "<< std::endl;
+    // std::cout << "[ID: " << static_cast<int>(servoId)<<"]"<<" Current position: " << current_position_rads << " rads "<< std::endl;
 
     return currentPositions_[idToIndex_[servoId]] = current_position_rads;
 }
@@ -416,7 +416,7 @@ bool FeetechServo::isMoving(uint8_t const &servoId)
 
 bool FeetechServo::writeTargetPosition(uint8_t const &servoId, int const &position, int const &speed, bool const &asynchronous)
 {
-    std::cout << "[ID: " << static_cast<int>(servoId)<<"] "<< "Writing target position: " << position << std::endl;
+    // std::cout << "[ID: " << static_cast<int>(servoId)<<"] "<< "Writing target position: " << position << std::endl;
     uint8_t params[6] = {0, 0, // Position
         0, 0, // Padding
         0, 0}; // Velocity


### PR DESCRIPTION
Will limit to about +- 7.5 rotations multiplied by the angular resolution (set higher -> lower resolution to achieve more rotations if needed). Eliminate the position loop on the driver side in favour of using the internal positioning loop